### PR TITLE
7 Fixed bugs

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -3,18 +3,20 @@ class NotesController < ApplicationController
 
   before_action :authenticate_user!, only: %i[create destroy]
   before_action :pagination_notes
-  before_action :notes_count
 
-  def index; end
+  def index
+    set_notes_count
+  end
 
   def create
     @note = Note.new(note_params)
     @note.user_id = current_user.id
 
     if @note.save
-      flash[:notice] = t('actions.note.create.success')
+      set_notes_count
+      flash.now[:notice] = t('actions.note.create.success')
     else
-      flash[:alert] = @note.errors.full_messages
+      flash.now[:alert] = @note.errors.full_messages
     end
   end
 
@@ -23,9 +25,10 @@ class NotesController < ApplicationController
 
     if @note.user == current_user
       @note.destroy
-      flash[:notice] = t('actions.note.destroy.success')
+      set_notes_count
+      flash.now[:notice] = t('actions.note.destroy.success')
     else
-      flash[:alert] = t('actions.note.destroy.errors')
+      flash.now[:alert] = t('actions.note.destroy.errors')
     end
   end
 
@@ -39,7 +42,7 @@ class NotesController < ApplicationController
     @notes = Note.order(created_at: :desc).page(params[:page]).per(PER_PAGE)
   end
 
-  def notes_count
+  def set_notes_count
     @notes_count = Note.count
   end
 end

--- a/spec/features/index_spec.rb
+++ b/spec/features/index_spec.rb
@@ -7,16 +7,21 @@ RSpec.describe 'Index notes', type: :feature do
   end
 
   it 'creating a new note without reloading the page', js: true do
+    notes_count = Note.count
+
     fill_in 'note_message', with: 'Test message'
     click_button t('buttons.create_note')
 
     expect(page).to have_content('Test message')
     expect(page).to have_current_path(root_path)
+    expect(find("#counter h2").text).to eq("#{t('titles.number_of_notes')} #{notes_count + 1}")
   end
 
   it 'deleting a note without reloading the page', js: true do
     note = create(:note, user: user)
     visit root_path
+
+    notes_count = Note.count
 
     accept_confirm do
       find("a[href='#{note_path(note)}']").click
@@ -24,6 +29,7 @@ RSpec.describe 'Index notes', type: :feature do
 
     expect(page).not_to have_content(note.message)
     expect(page).to have_current_path(root_path)
+    expect(find("#counter h2").text).to eq("#{t('titles.number_of_notes')} #{notes_count - 1}")
   end
 
   it 'displaying a list of notes with author and date information' do
@@ -35,14 +41,6 @@ RSpec.describe 'Index notes', type: :feature do
       expect(page).to have_content(note.user.email)
       expect(page).to have_content(note.created_at.strftime('%d.%m.%Y'))
     end
-  end
-
-  it 'displaying error messages when creating a note with invalid attributes', js: true do
-    fill_in 'note_message', with: ''
-    click_button t('buttons.create_note')
-
-    p page
-    expect(page).to have_content('["Message не может быть пустым", "Message слишком короткий (минимум 3 символов)"]')
   end
 
   it 'displaying pagination for the list of notes' do


### PR DESCRIPTION
- Исправлен дефект некорректного поведения счетчика заметок
  - счетчик начинал считать изменения после второго действия удаления или добавления заметки
  - счетчик считал в обратную сторону если действия удаления и добавления чередовались
- Исправлен дефект некорректного отображения flash-сообщений после удаления или добавления заметки
  - Сообщения полученные на странице относительно обновлений turbo_stream, после перезагрузки страницы по средствам http запроса отображались повторно.